### PR TITLE
Add `$news` to bot

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,10 @@
+# Dependencies
 import discord
+
+# Local dependencies
+from modules.csv import CSV
+from modules.news import News
+from modules.discordhelp import DiscordHelp
 
 client = discord.Client()
 
@@ -8,8 +14,18 @@ async def on_ready():
 
 @client.event
 async def on_message(message):
+
     if message.author == client.user:
         return
 
     if message.content.startswith('$hello'):
         await message.channel.send('Hello!')
+
+    if message.content.startswith('$news'):
+        result = News.getNews(message)
+
+        if not DiscordHelp.isValidLength(result):
+            result = "**Too many articles to list**"
+
+        await message.channel.send(result)
+

--- a/modules/discordhelp.py
+++ b/modules/discordhelp.py
@@ -1,0 +1,6 @@
+class DiscordHelp:
+    def isValidLength(message):
+        if len(message) > 2000:
+            return False
+
+        return True

--- a/modules/news.py
+++ b/modules/news.py
@@ -62,9 +62,6 @@ class News:
     # Get today's news from bleepingcomputer.com
     @staticmethod
     def bleeping_computer():
-        articles = []
-        return articles
-
         # This will hold the data points from each article
         articles_list = []
 
@@ -122,7 +119,7 @@ class News:
         # of 2000. You could make it send multiple messages but whatever.
         split_message = message.content.split(' ')
 
-        if len(split_message) < 3:
+        if len(split_message) < 3 or not isinstance(split_message[-1], int):
             return 'Format is ```$news [website] [number of articles]```'
 
         site = split_message[1]

--- a/modules/news.py
+++ b/modules/news.py
@@ -139,7 +139,7 @@ class News:
         formatter = Formatter()
         responses = []
         for i, article in enumerate(articles):
-            response = formatter.format("{num}. {title} by {author} ({link})", num=i, \
+            response = formatter.format("{num}. {title} by {author} ({link})", num=i+1, \
                                         title=article['title'], author=article['author'], \
                                         link=article['link'])
 

--- a/modules/news.py
+++ b/modules/news.py
@@ -62,10 +62,13 @@ class News:
     # Get today's news from bleepingcomputer.com
     @staticmethod
     def bleeping_computer():
+        articles = []
+        return articles
+
         # This will hold the data points from each article
         articles_list = []
 
-        url = "https://www.bleepingcomputer.com/"
+        url = "https://bleepingcomputer.com"
 
         soup = News.getSoup(url)
 
@@ -135,6 +138,9 @@ class News:
         except ValueError:
             result = '**Pick a valid number of results to return**'
             return result
+
+        if not articles:
+            return '**Sorry, there are no articles posted today!**'
 
         formatter = Formatter()
         responses = []

--- a/modules/news.py
+++ b/modules/news.py
@@ -112,6 +112,7 @@ class News:
         else:
             raise UnknownSiteError(site)
 
+    @staticmethod
     def getNews(message):
         # format is "$news site number", where number is the number
         # of articles to return, because discord has a character limit

--- a/modules/news.py
+++ b/modules/news.py
@@ -7,6 +7,10 @@ class News:
     # Sometimes requests doesn't work unless we have some specific headers *shrug*
     headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36'}
 
+    # This absolutely SUCKS i hate it
+    # I'll figure out a way to make this better, maybe make it an external file
+    help_message = '```$news - get cybersecurity news\n\nFormat is $news website [num]\n\nwebsite         website target\n[num]           number of articles to fetch\n                default: 5```'
+
     # Website Scraping Functions
 
     @staticmethod
@@ -119,13 +123,16 @@ class News:
         # of 2000. You could make it send multiple messages but whatever.
         split_message = message.content.split(' ')
 
-        if len(split_message) < 3 or not isinstance(split_message[-1], int):
-            return 'Format is ```$news [website] [number of articles]```'
+        if len(split_message) < 2 or len(split_message) > 3:
+            return News.help_message
 
         site = split_message[1]
-        n = int(split_message[2])
 
         try:
+            n = 5
+            if len(split_message) == 3:
+                n = int(split_message[2])
+
             articles = News.getNewsList(site)[:n]
 
         except (UnknownSiteError, IndexError):


### PR DESCRIPTION
This PR adds the ability for `$news` to be called in a channel.

Functionality is as follows:
`$news [site] [number]`
This returns a list of length `number` of articles, published today, from `site`.

This PR also adds the discordhelp.py module, which will hold helpful methods that make interacting with Discord easier.