### PR TITLE
Added bot run and token code

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,5 +1,6 @@
 # Dependencies
 import discord
+import os
 
 # Local dependencies
 from modules.csv import CSV
@@ -7,6 +8,10 @@ from modules.news import News
 from modules.discordhelp import DiscordHelp
 
 client = discord.Client()
+
+# set your bot token as an environment variable, e.g.,
+# `export JARVIS_TOKEN="<token>"`
+token = os.environ['JARVIS_TOKEN']
 
 @client.event
 async def on_ready():
@@ -29,3 +34,4 @@ async def on_message(message):
 
         await message.channel.send(result)
 
+client.run(token)


### PR DESCRIPTION
With this you now have to set your bot token as an environment variable, e.g., 
`export JARVIS_TOKEN="<token>"`, and when you launch the application the token is passed in and the application connects. This will be useful when we set up automatic deployment and/or testing further down the road.