### PR TITLE
Change BeautifulSoup scraping to RSS with feedparser

### DIFF
--- a/docs/news.md
+++ b/docs/news.md
@@ -1,0 +1,10 @@
+```
+$news - get cybersecurity news
+
+Usage:
+$news website [num]
+
+website         website target
+[num]           number of articles to fetch
+                default: 5
+```

--- a/modules/news.py
+++ b/modules/news.py
@@ -5,9 +5,11 @@ from time import mktime
 import feedparser
 
 class News:
-    # This absolutely SUCKS i hate it
-    # I'll figure out a way to make this better, maybe make it an external file
-    help_message = '```$news - get cybersecurity news\n\nFormat is $news website [num]\n\nwebsite         website target\n[num]           number of articles to fetch\n                default: 5```'
+    helpFile = 'docs/news.md'
+    # Get help message
+    def getHelp():
+        with open(News.helpFile, 'r') as fp:
+            return fp.read()
 
     # Feed URLs
     bleepingComputer = "https://bleepingcomputer.com/feed/"
@@ -35,7 +37,7 @@ class News:
         split_message = message.content.split(' ')
 
         if len(split_message) < 2 or len(split_message) > 3:
-            return News.help_message
+            return News.getHelp()
 
         site = split_message[1]
 

--- a/modules/news.py
+++ b/modules/news.py
@@ -1,124 +1,35 @@
-from bs4 import BeautifulSoup
 from datetime import date, datetime
 from string import Formatter
-import requests
+from time import mktime
+
+import feedparser
 
 class News:
-    # Sometimes requests doesn't work unless we have some specific headers *shrug*
-    headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.122 Safari/537.36'}
-
     # This absolutely SUCKS i hate it
     # I'll figure out a way to make this better, maybe make it an external file
     help_message = '```$news - get cybersecurity news\n\nFormat is $news website [num]\n\nwebsite         website target\n[num]           number of articles to fetch\n                default: 5```'
 
-    # Website Scraping Functions
+    # Feed URLs
+    bleepingComputer = "https://bleepingcomputer.com/feed/"
+    darkReading = "https://www.darkreading.com/rss_simple.asp"
 
+    # Get list of articles from url
     @staticmethod
-    def getSoup(url):
-        site = requests.get(url, headers=News.headers)
-        coverpage = site.content
-        soup = BeautifulSoup(coverpage, 'lxml')
-
-        return soup
-
-    @staticmethod
-    def darkReading():
-        articles_list = []
-
-        url = "https://darkreading.com/"
-
-        soup = News.getSoup(url)
-
-        # Get list of articles
-        articles = soup.find('div', id='left-column-inner')
-
-        today = date.today()
-
-        for article in articles.find_all('header', class_='strong medium'):
-            data = article.findNextSibling('div', style='overflow: hidden;')
-
-            date_str = str(data.find('span', class_='allcaps smaller').next_sibling).split(',')[-1].strip()
-            article_date = datetime.strptime(date_str, '%m/%d/%Y').date()
-            if article_date < today:
-                # We have hit the end of today's articles
-                break
-
-            info = {}
-
-            info['date'] = str(article_date)
-
-            link = article.find('a')['href']
-            info['link'] = 'https://darkreading.com' + link
-
-            info['title'] = article.find('a')['title']
-
-            description = data.find('span', class_='black smaller')
-            info['description'] = description.text
-
-            author = data.find('a', class_='color-link')
-            info['author'] = author.text
-
-            articles_list.append(info)
-
-        return articles_list
-
-
-    # Get today's news from bleepingcomputer.com
-    @staticmethod
-    def bleeping_computer():
-        # This will hold the data points from each article
-        articles_list = []
-
-        url = "https://bleepingcomputer.com"
-
-        soup = News.getSoup(url)
-
-        # Extract every article on the page
-        articles = soup.find_all('div', class_='bc_latest_news_text')
-
-        today = date.today()
-
-        # This is a little janky, but I'm still trying to figure out bs4
-        # Add data to
-        for article in articles:
-            date_str = article.find('li', class_='bc_news_date').text
-            article_date = datetime.strptime(date_str, '%b %d, %Y').date()
-            if article_date < today:
-                continue
-
-            info = {}
-
-            info['date'] = str(article_date)
-
-            title = article.contents[3].a
-            link = title['href']
-            info['link'] = link
-
-            title = title.text
-            info['title'] = title
-
-            description = article.contents[5].text
-            info['description'] = description
-
-            author = article.contents[7].a.text
-            info['author'] = author
-
-            articles_list.append(info)
-
-        return articles_list
+    def getEntries(url):
+        return feedparser.parse(url)['entries']
 
     @staticmethod
     def getNewsList(site):
         if site == "bleepingcomputer":
-            return News.bleeping_computer()
+            return RSS.getEntries(News.bleepingComputer)
         elif site == "darkreading":
-            return News.darkReading()
+            return RSS.getEntries(News.darkReading)
         else:
             raise UnknownSiteError(site)
 
     @staticmethod
     def getNews(message):
-        # format is "$news site number", where number is the number
+        # format is "$news site [number]", where number is the number
         # of articles to return, because discord has a character limit
         # of 2000. You could make it send multiple messages but whatever.
         split_message = message.content.split(' ')
@@ -148,7 +59,12 @@ class News:
 
         formatter = Formatter()
         responses = []
+        today = date.today()
         for i, article in enumerate(articles):
+            date_ = date.fromtimestamp(mktime(article['published_parsed']))
+            if today > date_:
+                break
+
             response = formatter.format("{num}. {title} by {author} ({link})", num=i+1, \
                                         title=article['title'], author=article['author'], \
                                         link=article['link'])

--- a/modules/news.py
+++ b/modules/news.py
@@ -21,9 +21,9 @@ class News:
     @staticmethod
     def getNewsList(site):
         if site == "bleepingcomputer":
-            return RSS.getEntries(News.bleepingComputer)
+            return News.getEntries(News.bleepingComputer)
         elif site == "darkreading":
-            return RSS.getEntries(News.darkReading)
+            return News.getEntries(News.darkReading)
         else:
             raise UnknownSiteError(site)
 

--- a/requriements.txt
+++ b/requriements.txt
@@ -2,3 +2,4 @@ discord.py==1.3.3
 beautifulsoup4==4.9.0
 requests==2.23.0
 lxml==4.5.0
+feedparser==5.2.1


### PR DESCRIPTION
This PR changes the way we get articles for the news function. Before, we were using BeautifulSoup 4 to scrape the homepage of each website, doing some convoluted logic (unique to each site) to parse the information we needed. Now, using the python module `feedparser`, we can easily get a list of articles in a standardized way, making it much simpler (and MUCH faster) to add new sites in the future.

This also changes the usage message for `$news` to be parsed from `docs/news.md` as opposed to being a string field in the News class. It can now be accessed with News.getHelp().