### PR TITLE
Add new websites to $news feature

### DIFF
--- a/modules/news.py
+++ b/modules/news.py
@@ -13,14 +13,14 @@ class News:
 
     # Feed URLs
     sites = {
-        "bleepingComputer": "https://bleepingcomputer.com/feed/",
-        "darkReading": "https://www.darkreading.com/rss_simple.asp",
+        "bleepingcomputer": "https://bleepingcomputer.com/feed/",
+        "darkreading": "https://www.darkreading.com/rss_simple.asp",
         "_3howley": "https://ethanizen.com//feed.xml",
         "plastic": "https://plasticuproject.github.io/blog/index.xml",
         "ycombinator": "https://news.ycombinator.com/rss",
         "nakedsecurity": "https://nakedsecurity.sophos.com/feed/",
         "threatpost": "https://threatpost.com/feed/",
-        "krebs": "https://krebsonsecurity.com/feed/",
+        "krebs": "https://krebsonsecurity.com/feed/"
     }
 
     # Get list of articles from url
@@ -30,22 +30,8 @@ class News:
 
     @staticmethod
     def getNewsList(site):
-        if site == "bleepingcomputer":
-            return News.getEntries(News.sites['bleepingComputer'])
-        elif site == "darkreading":
-            return News.getEntries(News.sites['darkReading'])
-        elif site == "3howley":
-            return News.getEntries(News.sites['_3howley'])
-        elif site == "plastic":
-            return News.getEntries(News.sites['plastic'])
-        elif site == "ycombinator":
-            return News.getEntries(News.sites['ycombinator'])
-        elif site =="nakedsecurity":
-            return News.getEntries(News.sites['nakedsecurity'])
-        elif site == "threatpost":
-            return News.getEntries(News.sites['threatpost'])
-        elif site == "krebs":
-            return News.getEntries(News.sites['krebs'])
+        if site in News.sites:
+            return News.getEntries(News.sites[site])
         else:
             raise UnknownSiteError(site)
 
@@ -69,7 +55,9 @@ class News:
             articles = News.getNewsList(site)[:n]
 
         except (UnknownSiteError, IndexError):
-            result = '**Valid sites are:** \n\nbleepingcomputer\ndarkreading\n3howley\nplastic\nycombinator\nthreatpost\nkrebs\nnakedsecurity'
+            sites = '\n'.join(News.sites.keys())
+
+            result = '**Valid sites are:**\n\n' + sites
             return result
 
         except ValueError:

--- a/modules/news.py
+++ b/modules/news.py
@@ -14,6 +14,12 @@ class News:
     # Feed URLs
     bleepingComputer = "https://bleepingcomputer.com/feed/"
     darkReading = "https://www.darkreading.com/rss_simple.asp"
+    _3howley = "https://ethanizen.com//feed.xml"
+    plastic = "https://plasticuproject.github.io/blog/index.xml"
+    ycombinator = "https://news.ycombinator.com/rss"
+    nakedsecurity = "https://nakedsecurity.sophos.com/feed/"
+    threatpost = "https://threatpost.com/feed/"
+    krebs = "https://krebsonsecurity.com/feed/"
 
     # Get list of articles from url
     @staticmethod
@@ -26,6 +32,10 @@ class News:
             return News.getEntries(News.bleepingComputer)
         elif site == "darkreading":
             return News.getEntries(News.darkReading)
+        elif site == "3howley":
+            return News.getEntries(News._3howley)
+        elif site == "plastic":
+            return News.getEntries(News.plastic)
         else:
             raise UnknownSiteError(site)
 
@@ -49,7 +59,7 @@ class News:
             articles = News.getNewsList(site)[:n]
 
         except (UnknownSiteError, IndexError):
-            result = '**Valid sites are:** \n\nbleepingcomputer\ndarkreading'
+            result = '**Valid sites are:** \n\nbleepingcomputer\ndarkreading\n3howley\nplastic'
             return result
 
         except ValueError:
@@ -57,19 +67,22 @@ class News:
             return result
 
         if not articles:
-            return '**Sorry, there are no articles posted today!**'
+            return '**Sorry, there are no articles!**'
 
         formatter = Formatter()
         responses = []
-        today = date.today()
         for i, article in enumerate(articles):
-            date_ = date.fromtimestamp(mktime(article['published_parsed']))
-            if today > date_:
-                break
+            title = article['title']
 
-            response = formatter.format("{num}. {title} by {author} ({link})", num=i+1, \
-                                        title=article['title'], author=article['author'], \
-                                        link=article['link'])
+            author = ''
+            if 'author' in article.keys():
+                author = ' by ' + article['author']
+
+            link = article['link']
+
+            response = formatter.format("{num}. {_title}{_author} ({_link})", num=i+1, \
+                                        _title=title, _author=author, \
+                                        _link=link)
 
             responses.append(response)
 

--- a/modules/news.py
+++ b/modules/news.py
@@ -12,14 +12,16 @@ class News:
             return fp.read()
 
     # Feed URLs
-    bleepingComputer = "https://bleepingcomputer.com/feed/"
-    darkReading = "https://www.darkreading.com/rss_simple.asp"
-    _3howley = "https://ethanizen.com//feed.xml"
-    plastic = "https://plasticuproject.github.io/blog/index.xml"
-    ycombinator = "https://news.ycombinator.com/rss"
-    nakedsecurity = "https://nakedsecurity.sophos.com/feed/"
-    threatpost = "https://threatpost.com/feed/"
-    krebs = "https://krebsonsecurity.com/feed/"
+    sites = {
+        "bleepingComputer": "https://bleepingcomputer.com/feed/",
+        "darkReading": "https://www.darkreading.com/rss_simple.asp",
+        "_3howley": "https://ethanizen.com//feed.xml",
+        "plastic": "https://plasticuproject.github.io/blog/index.xml",
+        "ycombinator": "https://news.ycombinator.com/rss",
+        "nakedsecurity": "https://nakedsecurity.sophos.com/feed/",
+        "threatpost": "https://threatpost.com/feed/",
+        "krebs": "https://krebsonsecurity.com/feed/",
+    }
 
     # Get list of articles from url
     @staticmethod
@@ -29,21 +31,21 @@ class News:
     @staticmethod
     def getNewsList(site):
         if site == "bleepingcomputer":
-            return News.getEntries(News.bleepingComputer)
+            return News.getEntries(News.sites['bleepingComputer'])
         elif site == "darkreading":
-            return News.getEntries(News.darkReading)
+            return News.getEntries(News.sites['darkReading'])
         elif site == "3howley":
-            return News.getEntries(News._3howley)
+            return News.getEntries(News.sites['_3howley'])
         elif site == "plastic":
-            return News.getEntries(News.plastic)
+            return News.getEntries(News.sites['plastic'])
         elif site == "ycombinator":
-            return News.getEntries(News.ycombinator)
+            return News.getEntries(News.sites['ycombinator'])
         elif site =="nakedsecurity":
-            return News.getEntries(News.nakedsecurity)
+            return News.getEntries(News.sites['nakedsecurity'])
         elif site == "threatpost":
-            return News.getEntries(News.threatpost)
+            return News.getEntries(News.sites['threatpost'])
         elif site == "krebs":
-            return News.getEntries(News.krebs)
+            return News.getEntries(News.sites['krebs'])
         else:
             raise UnknownSiteError(site)
 

--- a/modules/news.py
+++ b/modules/news.py
@@ -88,7 +88,7 @@ class News:
 
             link = article['link']
 
-            response = formatter.format("{num}. {_title}{_author} ({link})", num=i+1, \
+            response = formatter.format("{num}. {_title}{_author} (<{link}>)", num=i+1, \
                                         _title=title, _author=author, \
                                         link=link)
 

--- a/modules/news.py
+++ b/modules/news.py
@@ -36,6 +36,14 @@ class News:
             return News.getEntries(News._3howley)
         elif site == "plastic":
             return News.getEntries(News.plastic)
+        elif site == "ycombinator":
+            return News.getEntries(News.ycombinator)
+        elif site =="nakedsecurity":
+            return News.getEntries(News.nakedsecurity)
+        elif site == "threatpost":
+            return News.getEntries(News.threatpost)
+        elif site == "krebs":
+            return News.getEntries(News.krebs)
         else:
             raise UnknownSiteError(site)
 
@@ -59,7 +67,7 @@ class News:
             articles = News.getNewsList(site)[:n]
 
         except (UnknownSiteError, IndexError):
-            result = '**Valid sites are:** \n\nbleepingcomputer\ndarkreading\n3howley\nplastic'
+            result = '**Valid sites are:** \n\nbleepingcomputer\ndarkreading\n3howley\nplastic\nycombinator\nthreatpost\nkrebs\nnakedsecurity'
             return result
 
         except ValueError:
@@ -80,9 +88,9 @@ class News:
 
             link = article['link']
 
-            response = formatter.format("{num}. {_title}{_author} ({_link})", num=i+1, \
+            response = formatter.format("{num}. {_title}{_author} ({link})", num=i+1, \
                                         _title=title, _author=author, \
-                                        _link=link)
+                                        link=link)
 
             responses.append(response)
 


### PR DESCRIPTION
This PR adds 6 new websites for the `$news` function to pull from:

* https://plasticuporject.github.io/blog
* https://ethanizen.com
* https://news.ycombinator.com
* https://nakedsecurity.sophos.com
* https://threatpost.com
* https://krebsonsecurity.com

There are also two minor fixes:
1. In the case that an RSS feed doesn't contain an `author` field, it skips it and doesn't include it in the final string
1. Removes link previews so as not to take up too much space on Discord