### PR TITLE
Tldr

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -7,6 +7,7 @@ from modules.cve import CVE
 from modules.csv import CSV
 from modules.news import News
 from modules.discordhelp import DiscordHelp
+from modules.tldr import TLDR
 
 client = discord.Client()
 
@@ -38,5 +39,13 @@ async def on_message(message):
     if message.content.startswith('$cve'):
         result = CVE.cveSearch(message)
         await message.channel.send(result)
+
+    if message.content.startswith('$tldr'):
+        result = TLDR.tldr(message)
+        if isinstance(result, discord.Embed):
+            await message.channel.send(embed=result)
+        else:
+            await message.channel.send(result)
+
 
 client.run(token)

--- a/docs/tldr.md
+++ b/docs/tldr.md
@@ -6,7 +6,7 @@ $tldr command
 
 command             command to lookup
                     if a command has a space (`git commit`)
-                    put a `-` instead of a the space (`git-commit`)
+                    put a `-` instead of the space (`git-commit`)
 
 Examples:
 $tldr 7z

--- a/docs/tldr.md
+++ b/docs/tldr.md
@@ -4,7 +4,9 @@ $tldr - search tldr pages, community driven simplified man pages
 Usage:
 $tldr command
 
-command			command to lookup
+command             command to lookup
+                    if a command has a space (`git commit`)
+                    put a `-` instead of a the space (`git-commit`)
 
 Examples:
 $tldr 7z

--- a/docs/tldr.md
+++ b/docs/tldr.md
@@ -1,0 +1,16 @@
+```
+$tldr - search tldr pages, community driven simplified man pages
+
+Usage:
+$tldr command
+
+command			command to lookup
+
+Examples:
+$tldr 7z
+$tldr chmod
+
+Notes:
+Anything within a `{{` and `}}` in a tldr page are user supplied
+
+```

--- a/modules/tldr.py
+++ b/modules/tldr.py
@@ -1,0 +1,73 @@
+import requests
+import discord
+
+class TLDR:
+    BASE_URL = "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages/"
+
+    PLATFORMS = ['linux', 'common', 'osx', 'windows']
+
+    COMMANDS = requests.get("https://tldr.sh/assets/index.json").json()['commands']
+
+    helpFile = 'docs/tldr.md'
+
+    def notFound(command):
+        return '`' + command + "` documentation is not available. Consider contributing Pull Request to <https://github.com/tldr-pages/tldr>"
+
+    def getHelp():
+        with open(TLDR.helpFile, 'r') as fp:
+            return fp.read()
+
+    # Given a command str and list of platforms for that command,
+    # loop through general list of platforms in specific order
+    def getPageURL(command, platforms):
+        page = None
+        # This loop allows us to search for commands in a specific platform order
+        for platform in TLDR.PLATFORMS:
+            if platform in platforms:
+                page = TLDR.BASE_URL + platform + '/' + command + '.md'
+                break
+
+        return page
+
+    # Loop through list of all commands. If the command exists,
+    # return the json information of the command.
+    # Else, return None
+    def getPlatform(command):
+        for cmd in TLDR.COMMANDS:
+            if cmd['name'] == command:
+                return cmd['platform']
+
+        return None
+
+    def getPage(command):
+        platforms = TLDR.getPlatform(command)
+        # Command doesn't exist
+        if platforms == None:
+            return None
+
+        url = TLDR.getPageURL(command, platforms)
+
+        page = requests.get(url)
+        return page
+
+    def tldr(message):
+        splitMessage = message.content.split(' ')
+
+        if len(splitMessage) != 2 or splitMessage[1] == "-h":
+            return TLDR.getHelp()
+
+        # Get the command we are searching for
+        command = splitMessage[-1]
+
+        # Get request
+        page = TLDR.getPage(command)
+        if page is None:
+            return TLDR.notFound(command)
+
+        # page.content is class bytes so we need to decode it
+        content = "```markdown\n" + page.content.decode("utf-8") + "\n```"
+
+        # Create the embed
+        embed = discord.Embed(description=content)
+
+        return embed


### PR DESCRIPTION
This PR adds the ability for users to search the tldr pages using
the $tldr command. The logic for this command is contained in
modules/tldr.py. The help file is added in docs/tldr.md. This command
uses embeds to submit the tldr page.