### PR TITLE
Add --help

### DIFF
--- a/docs/tldr.md
+++ b/docs/tldr.md
@@ -2,11 +2,13 @@
 $tldr - search tldr pages, community driven simplified man pages
 
 Usage:
-$tldr command
+$tldr [-h | --help] [command]
 
 command             command to lookup
                     if a command has a space (`git commit`)
                     put a `-` instead of the space (`git-commit`)
+
+-h, --help			bring up this help message
 
 Examples:
 $tldr 7z

--- a/docs/tldr.md
+++ b/docs/tldr.md
@@ -4,11 +4,11 @@ $tldr - search tldr pages, community driven simplified man pages
 Usage:
 $tldr [-h | --help] [command]
 
+-h, --help          bring up this help message
 command             command to lookup
                     if a command has a space (`git commit`)
                     put a `-` instead of the space (`git-commit`)
 
--h, --help			bring up this help message
 
 Examples:
 $tldr 7z

--- a/modules/tldr.py
+++ b/modules/tldr.py
@@ -19,9 +19,9 @@ class TLDR:
 
     def isHelp(message):
         if message == '-h' or message == '--help':
-            return true
+            return True
 
-        return false
+        return False
 
     # Given a command str and list of platforms for that command,
     # loop through general list of platforms in specific order

--- a/modules/tldr.py
+++ b/modules/tldr.py
@@ -17,6 +17,12 @@ class TLDR:
         with open(TLDR.helpFile, 'r') as fp:
             return fp.read()
 
+    def isHelp(message):
+        if message == '-h' or message == '--help':
+            return true
+
+        return false
+
     # Given a command str and list of platforms for that command,
     # loop through general list of platforms in specific order
     def getPageURL(command, platforms):
@@ -53,7 +59,7 @@ class TLDR:
     def tldr(message):
         splitMessage = message.content.split(' ')
 
-        if len(splitMessage) != 2 or splitMessage[1] == "-h":
+        if len(splitMessage) != 2 or TLDR.isHelp(splitMessage[1]):
             return TLDR.getHelp()
 
         # Get the command we are searching for


### PR DESCRIPTION
This PR brings the tldr module to the `help` specification, allowing `-h`, `--help`, and `<no command> to bring up the help message.